### PR TITLE
Force java 8 for compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ organization := "com.lightbend.lagom"
 name := "lagom-service-locator-zookeeper"
 
 version := "1.0.0-SNAPSHOT"
+javaHome := Some(file(sys.env("JAVA_HOME")))
 
 scalaVersion := "2.11.8"
 scalacOptions += "-target:jvm-1.8"

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,6 @@ val lagomVersion = "1.0.0-RC1"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 
-initialize := {
-  val _ = initialize.value
-  if (sys.props("java.specification.version") != "1.8")
-    sys.error("Java 8 is required for this project.")
-}
 
 libraryDependencies ++= Seq(
   "com.lightbend.lagom" %% "lagom-javadsl-api"   % lagomVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ javaHome := Some(file(sys.env.getOrElse("JAVA_HOME","")))
 
 scalaVersion := "2.11.8"
 scalacOptions += "-target:jvm-1.8"
-val lagomVersion = "1.0.0-RC1"
+val lagomVersion = "1.0.0"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,34 @@
-organization := "com.lightbend.lagom"
+organization := "org.deeplearning4j"
 
 name := "lagom-service-locator-zookeeper"
+val lagomVersion = "1.1.0-RC1"
 
-version := "1.0.0-SNAPSHOT"
+version := lagomVersion
 javaHome := Some(file(sys.env.getOrElse("JAVA_HOME","")))
 
 scalaVersion := "2.11.8"
 scalacOptions += "-target:jvm-1.8"
-val lagomVersion = "1.0.0"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
+lazy val commonSettings = Seq(
+  version in ThisBuild := "<YOUR PLUGIN VERSION HERE>",
+  organization in ThisBuild := "<INSERT YOUR ORG HERE>"
+)
+
+lazy val root = (project in file(".")).
+  settings(
+    sbtPlugin := false,
+    name := "lagom-servicelocator-zookeeper",
+    description := "Lagom service locator zookeeper (fork)",
+    // This is an example.  bintray-sbt requires licenses to be specified
+    // (using a canonical name).
+    licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+    publishMavenStyle := true,
+    bintrayRepository in bintray := "lagom-servicelocator-zookeeper",
+    bintrayOrganization in bintray := Some("skymindio")
+  )
 
 libraryDependencies ++= Seq(
   "com.lightbend.lagom" %% "lagom-javadsl-api"   % lagomVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "com.lightbend.lagom"
 name := "lagom-service-locator-zookeeper"
 
 version := "1.0.0-SNAPSHOT"
-javaHome := Some(file(sys.env("JAVA_HOME")))
+javaHome := Some(file(sys.env.getOrElse("JAVA_HOME","")))
 
 scalaVersion := "2.11.8"
 scalacOptions += "-target:jvm-1.8"

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,14 @@ scalaVersion := "2.11.8"
 scalacOptions += "-target:jvm-1.8"
 val lagomVersion = "1.0.0-RC1"
 
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
+
+initialize := {
+  val _ = initialize.value
+  if (sys.props("java.specification.version") != "1.8")
+    sys.error("Java 8 is required for this project.")
+}
+
 libraryDependencies ++= Seq(
   "com.lightbend.lagom" %% "lagom-javadsl-api"   % lagomVersion,
   "org.apache.curator"   % "curator-x-discovery" % "2.11.0",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 
 libraryDependencies ++= Seq(
   "com.lightbend.lagom" %% "lagom-javadsl-api"   % lagomVersion,
-  "org.apache.curator"   % "curator-x-discovery" % "2.11.0",
-  "org.apache.curator"   % "curator-test"        % "2.11.0" % Test,
+  "org.apache.curator"   % "curator-x-discovery" % "2.7.0",
+  "org.apache.curator"   % "curator-test"        % "2.7.0" % Test,
   "org.scalatest"       %% "scalatest"           % "2.2.4" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "lagom-service-locator-zookeeper"
 version := "1.0.0-SNAPSHOT"
 
 scalaVersion := "2.11.8"
-
+scalacOptions += "-target:jvm-1.8"
 val lagomVersion = "1.0.0-RC1"
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 logLevel := Level.Warn
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/src/main/java/com/lightbend/lagom/discovery/zookeeper/ZooKeeperServiceRegistry.java
+++ b/src/main/java/com/lightbend/lagom/discovery/zookeeper/ZooKeeperServiceRegistry.java
@@ -43,9 +43,7 @@ public class ZooKeeperServiceRegistry implements Closeable {
         serviceDiscovery.unregisterService(serviceInstance);
     }
 
-    public CompletableFuture<Collection<URI>> locate(String serviceName) {
-        return CompletableFuture.supplyAsync(() -> locateBlocking(serviceName));
-    }
+
 
     protected Collection<URI> locateBlocking(String serviceName) {
         try {

--- a/src/main/java/com/lightbend/lagom/discovery/zookeeper/ZooKeeperServiceRegistry.java
+++ b/src/main/java/com/lightbend/lagom/discovery/zookeeper/ZooKeeperServiceRegistry.java
@@ -44,9 +44,7 @@ public class ZooKeeperServiceRegistry implements Closeable {
     }
 
     public CompletableFuture<Collection<URI>> locate(String serviceName) {
-        return CompletableFuture.supplyAsync(() -> {
-            return locateBlocking(serviceName);
-        });
+        return CompletableFuture.supplyAsync(() -> locateBlocking(serviceName));
     }
 
     protected Collection<URI> locateBlocking(String serviceName) {

--- a/src/main/java/com/lightbend/lagom/discovery/zookeeper/ZooKeeperServiceRegistry.java
+++ b/src/main/java/com/lightbend/lagom/discovery/zookeeper/ZooKeeperServiceRegistry.java
@@ -43,7 +43,9 @@ public class ZooKeeperServiceRegistry implements Closeable {
         serviceDiscovery.unregisterService(serviceInstance);
     }
 
-
+    public CompletableFuture<Collection<URI>> locate(String serviceName) {
+        return CompletableFuture.supplyAsync(() -> locateBlocking(serviceName));
+    }
 
     protected Collection<URI> locateBlocking(String serviceName) {
         try {


### PR DESCRIPTION
I'm not sure if this will be relevant for a broader audience, but I've noticed when compiling this in a docker container it was ignoring java home. This will force it to lookup java home from the environment variables when compiling. Maybe you have suggestions that are more suitable for the broader scala audience? Happy to update.

See:
http://stackoverflow.com/questions/27461385/invalid-source-release-1-8-on-jenkins-in-sbt

and the reason for SBT upgrade:
https://github.com/sbt/sbt/issues/2256
